### PR TITLE
Add docpad as parameter to _indexDocument function

### DIFF
--- a/out/lunr.plugin.js
+++ b/out/lunr.plugin.js
@@ -29,11 +29,11 @@
         };
       };
 
-      LunrPlugin.prototype.writeAfter = function() {
+      LunrPlugin.prototype.writeAfter = function(opts) {
         var index, indexName, _indexDocument, _ref;
-        _indexDocument = function(collection) {
+        _indexDocument = function(docpad, collection) {
           var indexCollection;
-          indexCollection = this.docpad.getCollection(collection);
+          indexCollection = docpad.getCollection(collection);
           if (indexCollection) {
             indexCollection.forEach(function(document) {
               return lunrdoc.index(indexName, document);
@@ -46,10 +46,10 @@
             index = _ref[indexName];
             if (Array.isArray(index.collection)) {
               index.collection.forEach(function(collection) {
-                _indexDocument(collection);
+                _indexDocument(this.docpad, collection);
               });
             } else {
-              _indexDocument(index.collection);
+              _indexDocument(this.docpad, index.collection);
             }
           }
           return lunrdoc.save();

--- a/src/lunr.plugin.coffee
+++ b/src/lunr.plugin.coffee
@@ -16,9 +16,9 @@ module.exports = (BasePlugin) ->
         return lunrdoc.getLunrSearchBlock(searchPage, placeholder, submit)
 
     # hook into the writeAfter event for generating the index/files
-    writeAfter: ->
-      _indexDocument = (collection) ->
-        indexCollection = @docpad.getCollection(collection)
+    writeAfter: (opts) ->
+      _indexDocument = (docpad, collection) ->
+        indexCollection = docpad.getCollection(collection)
         if indexCollection
           indexCollection.forEach (document) ->
             lunrdoc.index indexName, document
@@ -29,8 +29,8 @@ module.exports = (BasePlugin) ->
         for indexName, index of @config.indexes
           if Array.isArray(index.collection)
             index.collection.forEach (collection) ->
-              _indexDocument collection
+              _indexDocument @docpad, collection
               return
           else
-            _indexDocument(index.collection)
+            _indexDocument(@docpad, index.collection)
         lunrdoc.save()


### PR DESCRIPTION
Fixes error of "cannot getCollection of undefined" by passing the docpad object to the function directly. The docpad object was out-of-scope from within the function.
